### PR TITLE
Validaciones y correcciones: descripción 2000, límites de imágenes y robustez SSR

### DIFF
--- a/backend/src/controllers/properties.ts
+++ b/backend/src/controllers/properties.ts
@@ -193,13 +193,18 @@ propertiesRouter.post(
       const body = req.body as any;
 
       // Server-side validation: description max length (2000 chars)
-      const rawDescription = firstDefined(body, ["description", "descripcion"]);
-      if (typeof rawDescription === "string" && rawDescription.length > 2000) {
-        return res
-          .status(400)
-          .json({
-            error: "La descripción no puede superar los 2,000 caracteres.",
-          });
+      // Coerce description to a string safely (handle arrays or non-string values)
+      let rawDescription = firstDefined(body, ["description", "descripcion"]);
+      if (Array.isArray(rawDescription)) rawDescription = rawDescription[0];
+      const descString =
+        rawDescription === undefined || rawDescription === null
+          ? ""
+          : String(rawDescription);
+      if (descString.length > 2000) {
+        // Return a clear validation error
+        return res.status(400).json({
+          error: "La descripción no puede superar los 2,000 caracteres.",
+        });
       }
 
       // if there are files, upload each to Cloudinary and collect URLs
@@ -215,20 +220,16 @@ propertiesRouter.post(
 
           // Validate MIME type server-side again
           if (!file.mimetype || !file.mimetype.startsWith("image/")) {
-            return res
-              .status(400)
-              .json({
-                error: `El archivo ${file.originalname} no es una imagen válida.`,
-              });
+            return res.status(400).json({
+              error: `El archivo ${file.originalname} no es una imagen válida.`,
+            });
           }
 
           // Validate file size
           if (file.size > maxBytes) {
-            return res
-              .status(400)
-              .json({
-                error: `El archivo ${file.originalname} supera los 10 MB.`,
-              });
+            return res.status(400).json({
+              error: `El archivo ${file.originalname} supera los 10 MB.`,
+            });
           }
 
           try {
@@ -420,13 +421,17 @@ propertiesRouter.put(
       const body = req.body as any;
 
       // Server-side validation: description max length (2000 chars)
-      const rawDescription = firstDefined(body, ["description", "descripcion"]);
-      if (typeof rawDescription === "string" && rawDescription.length > 2000) {
-        return res
-          .status(400)
-          .json({
-            error: "La descripción no puede superar los 2,000 caracteres.",
-          });
+      // Coerce description to string safely (handle arrays or non-string values)
+      let rawDescription = firstDefined(body, ["description", "descripcion"]);
+      if (Array.isArray(rawDescription)) rawDescription = rawDescription[0];
+      const descString =
+        rawDescription === undefined || rawDescription === null
+          ? ""
+          : String(rawDescription);
+      if (descString.length > 2000) {
+        return res.status(400).json({
+          error: "La descripción no puede superar los 2,000 caracteres.",
+        });
       }
 
       // If there are files, upload each to Cloudinary and collect URLs
@@ -442,20 +447,16 @@ propertiesRouter.put(
 
           // Validate MIME type server-side
           if (!file.mimetype || !file.mimetype.startsWith("image/")) {
-            return res
-              .status(400)
-              .json({
-                error: `El archivo ${file.originalname} no es una imagen válida.`,
-              });
+            return res.status(400).json({
+              error: `El archivo ${file.originalname} no es una imagen válida.`,
+            });
           }
 
           // Validate file size
           if (file.size > maxBytes) {
-            return res
-              .status(400)
-              .json({
-                error: `El archivo ${file.originalname} supera los 10 MB.`,
-              });
+            return res.status(400).json({
+              error: `El archivo ${file.originalname} supera los 10 MB.`,
+            });
           }
 
           try {

--- a/frontend/public/placeholder.svg
+++ b/frontend/public/placeholder.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="#CBD5E1" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><path d="M8 14l2.5-3 2 2.5L16 10l4 6H4z"/></svg>

--- a/frontend/services/properties.ts
+++ b/frontend/services/properties.ts
@@ -122,7 +122,11 @@ export async function getPropertyById(id: string) {
     const base = `http://localhost:${process.env.PORT || 3000}`;
     const url = new URL(`/api/properties/${id}`, base).toString();
     const res = await fetch(url);
-    if (!res.ok) throw new Error("Failed to fetch property");
+    if (!res.ok) {
+      // Return null for server-side rendering when backend fails so React Server
+      // Components can render a friendly fallback instead of throwing.
+      return null as any;
+    }
     return res.json();
   }
 


### PR DESCRIPTION
Incluye las siguientes mejoras desde `dev` hacia `main`:

- Frontend
  - Forzar máximo de 2,000 caracteres para la descripción y mostrar contador.
  - Validación cliente: aceptar solo `image/*`, por archivo ≤ 10 MB, máximo 10 imágenes; notificación cuando se intentan subir más.
  - Añadido `placeholder.svg` para evitar 404 en producción.
  - SSR: evitar que `getPropertyById` arroje en SSR cuando backend responde non-OK (devuelve null) para no romper Server Components.

- Backend
  - Validación servidor: descripción ≤ 2,000 en create/update.
  - Multer: aceptar `image/*`, fileSize 10 MB, máximo 10 archivos.
  - Validaciones por archivo antes de subir a Cloudinary y mensajes 400 claros en violaciones.

Notas:
- Recomiendo revisar el comportamiento CSRF en producción (SameSite/Cookies) si frontend y backend están en dominios distintos.
