### PR TITLE
Fix: notifications position + form validation for create property

### DIFF
--- a/frontend/app/dashboard/properties/create/page.tsx
+++ b/frontend/app/dashboard/properties/create/page.tsx
@@ -29,6 +29,41 @@ export default function CreatePropertyPage() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    // Validate required fields (none should be empty except images)
+    const missing: string[] = [];
+    if (!title || title.trim() === "") missing.push("Título");
+    if (!description || description.trim() === "") missing.push("Descripción");
+    if (!price || String(price).trim() === "") missing.push("Precio");
+    if (!currency || String(currency).trim() === "") missing.push("Moneda");
+    if (!province || province.trim() === "") missing.push("Provincia");
+    if (!city || city.trim() === "") missing.push("Municipio");
+    if (!neighborhood || neighborhood.trim() === "") missing.push("Sector");
+    if (!type || String(type).trim() === "") missing.push("Tipo");
+    if (!category || String(category).trim() === "") missing.push("Categoría");
+    if (!bedrooms || String(bedrooms).trim() === "")
+      missing.push("Habitaciones");
+    if (!bathrooms || String(bathrooms).trim() === "") missing.push("Baños");
+    if (!halfBathrooms || String(halfBathrooms).trim() === "")
+      missing.push("Medios baños");
+    if (!parkingSpaces || String(parkingSpaces).trim() === "")
+      missing.push("Parqueos");
+    if (!builtArea || String(builtArea).trim() === "")
+      missing.push("Construcción (m²)");
+
+    if (missing.length > 0) {
+      try {
+        notify({
+          type: "error",
+          title: "Faltan campos",
+          message: `Por favor complete los siguientes campos antes de enviar: ${missing.join(
+            ", "
+          )}`,
+          duration: 6000,
+        });
+      } catch {}
+      return;
+    }
+
     setLoading(true);
 
     const payload = {

--- a/frontend/components/Notification.tsx
+++ b/frontend/components/Notification.tsx
@@ -71,7 +71,7 @@ export function NotificationProvider({
       {children}
       <div
         aria-live="polite"
-        className="pointer-events-none fixed inset-0 z-50 flex items-end sm:items-start sm:justify-end p-4"
+        className="pointer-events-none fixed inset-0 z-50 flex items-end sm:items-start md:items-start sm:justify-end md:justify-end p-4"
       >
         <div className="w-full max-w-xs sm:max-w-sm flex flex-col gap-2">
           {toasts.map((t) => (


### PR DESCRIPTION
- Ajusta la posición de las notificaciones para que se muestren en la parte superior en pantallas sm y md (archivo: `frontend/components/Notification.tsx`).
- Añade validación previa al envío en la página de crear propiedad para asegurar que ningún campo quede vacío (excepto imágenes) y notificar al usuario (archivo: `frontend/app/dashboard/properties/create/page.tsx`).

Cambios pequeños y focalizados. Pruebas manuales recomendadas en el entorno local.